### PR TITLE
Feature/customizable net labels

### DIFF
--- a/handlers/eth1Deposits.go
+++ b/handlers/eth1Deposits.go
@@ -150,6 +150,7 @@ func Eth1DepositsLeaderboard(w http.ResponseWriter, r *http.Request) {
 
 	data.Data = types.EthOneDepositLeaderBoardPageData{
 		DepositContract: utils.Config.Indexer.Eth1DepositContractAddress,
+		Eth1Label:       utils.Config.Frontend.Eth1Label,
 	}
 
 	err := eth1DepositsLeaderboardTemplate.ExecuteTemplate(w, "layout", data)

--- a/handlers/eth1Deposits.go
+++ b/handlers/eth1Deposits.go
@@ -33,6 +33,8 @@ func Eth1Deposits(w http.ResponseWriter, r *http.Request) {
 
 	pageData.Stats = services.GetLatestStats()
 	pageData.DepositContract = utils.Config.Indexer.Eth1DepositContractAddress
+	pageData.Eth1Label = utils.Config.Frontend.Eth1Label
+	pageData.Eth2Label = utils.Config.Frontend.Eth2Label
 
 	data := InitPageData(w, r, "eth1Deposits", "/deposits/eth1", "Eth1 Deposits")
 	data.HeaderAd = true

--- a/handlers/eth2Deposits.go
+++ b/handlers/eth2Deposits.go
@@ -18,8 +18,12 @@ func Eth2Deposits(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html")
 
+	eth2DepositsPageData := types.Eth2DepositsPageData{}
+	eth2DepositsPageData.Eth2Label = utils.Config.Frontend.Eth2Label
+
 	data := InitPageData(w, r, "eth2Deposits", "/deposits/eth2", "Eth2 Deposits")
 	data.HeaderAd = true
+	data.Data = eth2DepositsPageData
 
 	err := eth2DepositsTemplate.ExecuteTemplate(w, "layout", data)
 

--- a/handlers/pageData.go
+++ b/handlers/pageData.go
@@ -68,6 +68,8 @@ func InitPageData(w http.ResponseWriter, r *http.Request, active, path, title st
 		DefaultCurrency:       utils.Config.Frontend.Eth1Currency,
 		DefaultCurrencyName:   utils.Config.Frontend.Eth1CurrencyName,
 		NoAds:                 user.Authenticated && user.Subscription != "",
+		Eth1Label:             utils.Config.Frontend.Eth1Label,
+		Eth2Label:             utils.Config.Frontend.Eth2Label,
 	}
 	data.EthPrice = price.GetEthPrice(data.Currency)
 	data.ExchangeRate = price.GetEthPrice(data.Currency)

--- a/services/services.go
+++ b/services/services.go
@@ -148,12 +148,14 @@ func indexPageDataUpdater() {
 }
 
 func getIndexPageData() (*types.IndexPageData, error) {
-	currency := "ETH"
-
 	data := &types.IndexPageData{}
 	data.Mainnet = utils.Config.Chain.Mainnet
 	data.NetworkName = utils.Config.Chain.Network
 	data.DepositContract = utils.Config.Indexer.Eth1DepositContractAddress
+	data.Currency = utils.Config.Frontend.Eth1Currency
+	data.CurrencyName = utils.Config.Frontend.Eth1CurrencyName
+
+	currency := data.Currency
 
 	var epoch uint64
 	err := db.DB.Get(&epoch, "SELECT COALESCE(MAX(epoch), 0) FROM epochs")

--- a/templates/eth1Deposits.html
+++ b/templates/eth1Deposits.html
@@ -61,13 +61,13 @@
         <div class="container my-2">
             <div class="d-md-flex py-2 justify-content-md-between mb-3">
                 <div class="heading">
-                    <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-file-signature mr-2"></i></i>Eth1 Deposits</h1>
+                    <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-file-signature mr-2"></i></i>{{ .Eth1Label }} Deposits</h1>
                 </div>
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb font-size-1 mb-0" style="padding:0; background-color:transparent;">
                         <li class="breadcrumb-item"><a href="/" title="Home">Home</a></li>
                         <li class="breadcrumb-item"><a href="/validators" title="Validators">Validators</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">Eth1 Deposits</li>
+                        <li class="breadcrumb-item active" aria-current="page">{{ .Eth1Label }} Deposits</li>
                     </ol>
                 </nav>
             </div>
@@ -129,21 +129,21 @@
             <div>
                 {{ template "depositChart" . }}
             </div>
-            <h6 class="my-2 text-muted">This table displays the deposits made on Eth1 for validators who wish to join
-                the Eth2 Beacon Chain.</h6>
+            <h6 class="my-2 text-muted">This table displays the deposits made on {{ .Eth1Label }} for validators who wish to join
+                the {{ .Eth2Label }} Beacon Chain.</h6>
             <div class="card">
                 <div class="card-body px-0 py-2">
                     <div class="table-responsive pt-2">
                         <table class="table" id="deposits">
                             <thead>
                             <tr>
-                                <th>Eth1 Address</th>
+                                <th>{{ .Eth1Label }} Address</th>
                                 <th>Validator Key</th>
                                 <th>Amount</th>
-                                <th>Eth1 TxHash</th>
+                                <th>{{ .Eth1Label }} TxHash</th>
                                 <th>Time</th>
-                                <th>Eth1 Block</th>
-                                <th>Eth2 Validator State</th>
+                                <th>{{ .Eth1Label }} Block</th>
+                                <th>{{ .Eth2Label }} Validator State</th>
                                 <th>Valid Signature</th>
                             </tr>
                             </thead>

--- a/templates/eth1DepositsLeaderboard.html
+++ b/templates/eth1DepositsLeaderboard.html
@@ -9,7 +9,7 @@
         var debounce = null
         var scatterOptions = {
             title: {
-                text: "Validators by Eth1 Address"
+                text: "Validators by {{ .Eth1Label }} Address"
             },
             chart: {
                 type: 'column',
@@ -51,7 +51,7 @@
             },
             xAxis: {
                 title: {
-                    text: 'Eth1 Address',
+                    text: '{{ .Eth1Label }} Address',
                     style: {
                         color: 'var(--font-color)'
                     }
@@ -184,14 +184,14 @@
             <div class="my-3">
                 <div class="d-md-flex py-2 justify-content-md-between">
                     <div class="heading">
-                        <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-file-signature mr-2"></i></i>Eth1 Deposits
+                        <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-file-signature mr-2"></i></i>{{ .Eth1Label }} Deposits
                             Leaderboard</h1>
                     </div>
                     <nav aria-label="breadcrumb">
                         <ol class="breadcrumb font-size-1 mb-0" style="padding:0; background-color:transparent;">
                             <li class="breadcrumb-item"><a href="/" title="Home">Home</a></li>
                             <li class="breadcrumb-item"><a href="/validators" title="Validators">Validators</a></li>
-                            <li class="breadcrumb-item active" aria-current="page">Eth1 Deposits</li>
+                            <li class="breadcrumb-item active" aria-current="page">{{ .Eth1Label }} Deposits</li>
                         </ol>
                     </nav>
                 </div>
@@ -457,7 +457,7 @@
                     </svg>
                 </div>
             </div>
-            <h6 class="">This table displays the leaderboard for deposits made by Eth1 Addresses to the Deposit
+            <h6 class="">This table displays the leaderboard for deposits made by {{ .Eth1Label }} Addresses to the Deposit
                 Contract</h6>
             <div class="card">
                 <div class="card-body px-0 py-2">
@@ -465,7 +465,7 @@
                         <table class="table" id="deposits">
                             <thead>
                             <tr>
-                                <th>Eth1 Address</th>
+                                <th>{{ .Eth1Label }} Address</th>
                                 <!-- <th>Name</th> -->
                                 <th>Total Deposited</th>
                                 <th data-toggle="tooltip" title="Valid deposits">Valid</th>

--- a/templates/eth2Deposits.html
+++ b/templates/eth2Deposits.html
@@ -53,17 +53,17 @@
         <div class="container mt-2">
             <div class="my-3">
                 <div class="d-md-flex py-2 justify-content-md-between">
-                    <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-clipboard-check mr-2"></i>Eth2 Deposits</h1>
+                    <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-clipboard-check mr-2"></i>{{ .Eth2Label}} Deposits</h1>
                     <nav aria-label="breadcrumb">
                         <ol class="breadcrumb font-size-1 mb-0" style="padding: 0; background-color: transparent;">
                             <li class="breadcrumb-item"><a href="/" title="Home">Home</a></li>
                             <li class="breadcrumb-item"><a href="/validators" title="Validators">Validators</a></li>
-                            <li class="breadcrumb-item active" aria-current="page">Eth2 Deposits</li>
+                            <li class="breadcrumb-item active" aria-current="page">{{ .Eth2Label}} Deposits</li>
                         </ol>
                     </nav>
                 </div>
             </div>
-            <h6>This table displays the deposits received by the Eth2 Beacon Chain.</h6>
+            <h6>This table displays the deposits received by the {{ .Eth2Label}} Beacon Chain.</h6>
             <div class="card">
                 <div class="card-body px-0 py-2">
                     <div class="table-responsive pt-2">

--- a/templates/index/genesis.html
+++ b/templates/index/genesis.html
@@ -7,7 +7,7 @@
 <div style="position:relative" class="card mt-3 index-stats">
   <div class="card-header pt-3">
     <div class="row">
-      {{ template "networkStats" }}
+      {{ template "networkStats" . }}
     </div>
   </div>
   <div class="card-body">
@@ -71,7 +71,7 @@
 </div>
 <div class="row">
   <div class="col-lg-6 mt-3 pr-lg-2">
-    {{template "recentEpochs"}}
+    {{template "recentEpochs" .}}
   </div>
   <div class="col-lg-6 mt-3 pl-lg-2">
     {{ template "recentBlocks"}}

--- a/templates/index/index.html
+++ b/templates/index/index.html
@@ -50,7 +50,7 @@
                             }
                         },
                         yAxis: [{
-                            title: {text: 'Balance [ETH]'},
+                            title: {text: 'Balance [{{.Currency}}]'},
                             labels: {
                                 formatter: function () {
                                     return this.value.toFixed(0);
@@ -68,7 +68,7 @@
                         }],
                         series: [
                             {
-                                name: "Staked Ether",
+                                name: "Staked {{.CurrencyName}}",
                                 yAxis: 0,
                                 data: {{.StakedEtherChartData}}
                             },

--- a/templates/index/networkStats.html
+++ b/templates/index/networkStats.html
@@ -33,7 +33,7 @@
 <div class="col-md-4">
   <div class="d-flex justify-content-between">
     <div class="p-2">
-      <div class="text-secondary mb-0">Staked Ether</div>
+      <div class="text-secondary mb-0">Staked {{ .CurrencyName }}</div>
       <h5 class="font-weight-normal mb-0">
         <span data-toggle="tooltip" data-placement="top" title="The sum of all effective balances">${ page.staked_ether.toLocaleString('en-GB') || 0 }</span>
       </h5>

--- a/templates/index/postGenesis.html
+++ b/templates/index/postGenesis.html
@@ -7,7 +7,7 @@
   {{end}}
   <div class="card-header pt-3">
     <div class="row">
-      {{ template "networkStats" }}
+      {{ template "networkStats" . }}
     </div>
   </div>
   <div class="card-body">
@@ -20,7 +20,7 @@
 </div>
 <div class="row">
   <div class="col-lg-6 mt-3 pr-lg-2">
-    {{template "recentEpochs"}}
+    {{template "recentEpochs" .}}
   </div>
   <div class="col-lg-6 mt-3 pl-lg-2">
     {{ template "recentBlocks"}}

--- a/templates/index/recentEpochs.html
+++ b/templates/index/recentEpochs.html
@@ -16,7 +16,7 @@
           <th>Epoch</th>
           <th>Time</th>
           <th>Final</th>
-          <th>Eligible (ETH)</th>
+          <th>Eligible ({{ .Currency }})</th>
           <th>Voted</th>
         </tr>
         </thead>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -416,11 +416,11 @@
                             <hr>
                             <a class="dropdown-item" href="/validators/eth1deposits">
                                 <span class="nav-icon"><i class="fas fa-file-signature mr-2"></i></span>
-                                <span class="nav-text">Eth1 Deposits</span>
+                                <span class="nav-text">{{ .Eth1Label }} Deposits</span>
                             </a>
                             <a class="dropdown-item" href="/validators/eth2deposits">
                                 <span class="nav-icon"><i class="fas fa-clipboard-check mr-2"></i></span>
-                                <span class="nav-text">Eth2 Deposits</span>
+                                <span class="nav-text">{{ .Eth2Label }} Deposits</span>
                             </a>
                         </div>
                     </li>

--- a/types/templates.go
+++ b/types/templates.go
@@ -874,6 +874,7 @@ type EthOneDepositsPageData struct {
 
 type EthOneDepositLeaderBoardPageData struct {
 	DepositContract string
+	Eth1Label       string
 }
 
 // EpochsPageData is a struct to hold epoch data for the epochs page

--- a/types/templates.go
+++ b/types/templates.go
@@ -872,6 +872,8 @@ type EthOneDepositsPageData struct {
 	*Stats
 	DepositContract string
 	DepositChart    *ChartsPageDataChart
+	Eth1Label       string
+	Eth2Label       string
 }
 
 type EthOneDepositLeaderBoardPageData struct {

--- a/types/templates.go
+++ b/types/templates.go
@@ -152,6 +152,8 @@ type IndexPageData struct {
 	DepositChart              *ChartsPageDataChart
 	DepositDistribution       *ChartsPageDataChart
 	Countdown                 interface{}
+	Currency                  string
+	CurrencyName              string
 }
 
 type IndexPageDataEpochs struct {

--- a/types/templates.go
+++ b/types/templates.go
@@ -385,6 +385,10 @@ type ValidatorsLeaderboardPageData struct {
 	Currency string
 }
 
+type Eth2DepositsPageData struct {
+	Eth2Label string
+}
+
 type ChartDataPoint struct {
 	X     float64 `json:"x"`
 	Y     float64 `json:"y"`

--- a/types/templates.go
+++ b/types/templates.go
@@ -59,6 +59,8 @@ type PageData struct {
 	DefaultCurrency       string
 	DefaultCurrencyName   string
 	NoAds                 bool
+	Eth1Label             string
+	Eth2Label             string
 }
 
 // Meta is a struct to hold metadata about the page


### PR DESCRIPTION
The pull request make use of two configuration variables: _eth1Label_ and _eth2Label_, and considers places where _Eth1_ and _Eth2_ labels were hardcoded.

The request addresses following issues:

1. Closes issue #6, by making the staking token symbol on the main page dashboards configurable (they equal to _eth1Currency_ and _eth1CurrencyName_ configuration variables):
    ![image](https://user-images.githubusercontent.com/25086020/135725809-c98ad2fe-3a51-40c9-bcf2-55bc38516b5a.png)

1. Fully closes issue #10, by making the labels on "Validators/Deposit Leaderboard" page configurable and equal to _eth1Label_:
    ![image](https://user-images.githubusercontent.com/25086020/135725886-e8e516e3-958f-4bdb-b1ec-3801353588cf.png)

1. Closes issue #12, by making "Validators/Eth2 Deposits" menu item to be replaced be "Validators/{_eth2Label_} Deposits", and replacing "Eth1" label with _eth2Label_ on the page itself:
    ![image](https://user-images.githubusercontent.com/25086020/135726029-9906fbe0-35e0-4854-b322-75a3319e5dfd.png)

1. I have not find an issue, but on the "Validators/Eth1 Deposits" page, "Eth1" and "Eth2" labels were actively used. The pull request also addresses this problem with making them equal to _eth1Label_ and _eth2Label_ configuration variables correspondingly (maybe we can relate the problem with the issue #10):
    ![image](https://user-images.githubusercontent.com/25086020/135726106-66bd8f4f-66d1-498f-891c-ade6f7c9eca5.png)




 